### PR TITLE
chore: Run build on prepack (fixes missing files in NPM package)

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "build": "rimraf dist && tsc",
     "lint": "tsc --noEmit -p tsconfig.lint.json && eslint --ignore-path .gitignore .",
     "lint-fix": "tsc --noEmit -p tsconfig.lint.json && eslint --fix --ignore-path .gitignore .",
-    "test": "npm run build && node dist/bin.js test/"
+    "test": "npm run build && node dist/bin.js test/",
+    "prepack": "npm run build"
   },
   "engines": {
     "node": ">=18.7.0"


### PR DESCRIPTION
Unfortunately, v0.1.0 was released without any JS code due to a missing
build step, which is now fixed by this patch.

Release-As: 0.1.1