### PR TITLE
feat: Support custom extensions via env variable

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,12 +20,15 @@ jobs:
       - run: npm run lint
 
   test:
-    name: test - Node.js ${{ matrix.node-version }}
-    runs-on: ubuntu-latest
     strategy:
       matrix:
+        os:
+          - ubuntu-latest
+          - windows-latest
         node-version:
           - 18
+    name: test (${{ matrix.os }}) - Node.js ${{ matrix.node-version }}
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,8 +17,10 @@
       "devDependencies": {
         "@meyfa/eslint-config": "2.0.2",
         "@types/node": "18.6.2",
+        "@types/sinon": "^10.0.13",
         "eslint": "8.23.0",
         "rimraf": "3.0.2",
+        "sinon": "^14.0.0",
         "typescript": "4.8.2"
       },
       "engines": {
@@ -188,6 +190,41 @@
       "integrity": "sha512-LwzQKA4vzIct1zNZzBmRKI9QuNpLgTQMEjsQLf3BXuGYb3QPTP4Yjf6mkdX+X1mYttZ808QpOwAzZjv28kq7DA==",
       "dev": true
     },
+    "node_modules/@sinonjs/commons": {
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.3.tgz",
+      "integrity": "sha512-xkNcLAn/wZaX14RPlwizcKicDk9G3F8m2nU3L7Ukm5zBgTwiT0wsoFAHx9Jq56fJA1z/7uKGtCRu16sOUCLIHQ==",
+      "dev": true,
+      "dependencies": {
+        "type-detect": "4.0.8"
+      }
+    },
+    "node_modules/@sinonjs/fake-timers": {
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-9.1.2.tgz",
+      "integrity": "sha512-BPS4ynJW/o92PUR4wgriz2Ud5gpST5vz6GQfMixEDK0Z8ZCUv2M7SkBLykH56T++Xs+8ln9zTGbOvNGIe02/jw==",
+      "dev": true,
+      "dependencies": {
+        "@sinonjs/commons": "^1.7.0"
+      }
+    },
+    "node_modules/@sinonjs/samsam": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-6.1.1.tgz",
+      "integrity": "sha512-cZ7rKJTLiE7u7Wi/v9Hc2fs3Ucc3jrWeMgPHbbTCeVAB2S0wOBbYlkJVeNSL04i7fdhT8wIbDq1zhC/PXTD2SA==",
+      "dev": true,
+      "dependencies": {
+        "@sinonjs/commons": "^1.6.0",
+        "lodash.get": "^4.4.2",
+        "type-detect": "^4.0.8"
+      }
+    },
+    "node_modules/@sinonjs/text-encoding": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.2.tgz",
+      "integrity": "sha512-sXXKG+uL9IrKqViTtao2Ws6dy0znu9sOaP1di/jKGW1M6VssO8vlpXCQcpZ+jisQ1tTFAC5Jo/EOzFbggBagFQ==",
+      "dev": true
+    },
     "node_modules/@tsconfig/node10": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.9.tgz",
@@ -224,6 +261,21 @@
       "version": "18.6.2",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.6.2.tgz",
       "integrity": "sha512-KcfkBq9H4PI6Vpu5B/KoPeuVDAbmi+2mDBqGPGUgoL7yXQtcWGu2vJWmmRkneWK3Rh0nIAX192Aa87AqKHYChQ=="
+    },
+    "node_modules/@types/sinon": {
+      "version": "10.0.13",
+      "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-10.0.13.tgz",
+      "integrity": "sha512-UVjDqJblVNQYvVNUsj0PuYYw0ELRmgt1Nt5Vk0pT5f16ROGfcKJY8o1HVuMOJOpD727RrGB9EGvoaTQE5tgxZQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/sinonjs__fake-timers": "*"
+      }
+    },
+    "node_modules/@types/sinonjs__fake-timers": {
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-8.1.2.tgz",
+      "integrity": "sha512-9GcLXF0/v3t80caGs5p2rRfkB+a8VBGLJZVih6CNFkx8IZ994wiKKLSRs9nuFwk1HevWs/1mnUmkApGrSGsShA==",
+      "dev": true
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "5.35.1",
@@ -1993,6 +2045,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/isarray": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+      "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==",
+      "dev": true
+    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -2035,6 +2093,12 @@
         "json5": "lib/cli.js"
       }
     },
+    "node_modules/just-extend": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.2.1.tgz",
+      "integrity": "sha512-g3UB796vUFIY90VIv/WX3L2c8CS2MdWUww3CNrYmqza1Fg0DURc2K/O4YrnklBdQarSJ/y8JnJYDGc+1iumQjg==",
+      "dev": true
+    },
     "node_modules/levn": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
@@ -2060,6 +2124,12 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==",
+      "dev": true
     },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
@@ -2135,6 +2205,19 @@
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true
+    },
+    "node_modules/nise": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-5.1.1.tgz",
+      "integrity": "sha512-yr5kW2THW1AkxVmCnKEh4nbYkJdB3I7LUkiUgOvEkOp414mc2UMaHMA7pjq1nYowhdoJZGwEKGaQVbxfpWj10A==",
+      "dev": true,
+      "dependencies": {
+        "@sinonjs/commons": "^1.8.3",
+        "@sinonjs/fake-timers": ">=5",
+        "@sinonjs/text-encoding": "^0.7.1",
+        "just-extend": "^4.0.2",
+        "path-to-regexp": "^1.7.0"
+      }
     },
     "node_modules/object-inspect": {
       "version": "1.12.2",
@@ -2292,6 +2375,15 @@
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true
+    },
+    "node_modules/path-to-regexp": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
+      "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
+      "dev": true,
+      "dependencies": {
+        "isarray": "0.0.1"
+      }
     },
     "node_modules/path-type": {
       "version": "4.0.0",
@@ -2505,6 +2597,33 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/sinon": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-14.0.0.tgz",
+      "integrity": "sha512-ugA6BFmE+WrJdh0owRZHToLd32Uw3Lxq6E6LtNRU+xTVBefx632h03Q7apXWRsRdZAJ41LB8aUfn2+O4jsDNMw==",
+      "dev": true,
+      "dependencies": {
+        "@sinonjs/commons": "^1.8.3",
+        "@sinonjs/fake-timers": "^9.1.2",
+        "@sinonjs/samsam": "^6.1.1",
+        "diff": "^5.0.0",
+        "nise": "^5.1.1",
+        "supports-color": "^7.2.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/sinon"
+      }
+    },
+    "node_modules/sinon/node_modules/diff": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-5.1.0.tgz",
+      "integrity": "sha512-D+mk+qE8VC/PAUrlAU34N+VfXev0ghe5ywmpqrawphmVZc1bEfn56uo9qpyGp1p4xpzOHkSW4ztBd6L7Xx4ACw==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
     "node_modules/slash": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
@@ -2702,6 +2821,15 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/type-fest": {
@@ -2950,6 +3078,41 @@
       "integrity": "sha512-LwzQKA4vzIct1zNZzBmRKI9QuNpLgTQMEjsQLf3BXuGYb3QPTP4Yjf6mkdX+X1mYttZ808QpOwAzZjv28kq7DA==",
       "dev": true
     },
+    "@sinonjs/commons": {
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.3.tgz",
+      "integrity": "sha512-xkNcLAn/wZaX14RPlwizcKicDk9G3F8m2nU3L7Ukm5zBgTwiT0wsoFAHx9Jq56fJA1z/7uKGtCRu16sOUCLIHQ==",
+      "dev": true,
+      "requires": {
+        "type-detect": "4.0.8"
+      }
+    },
+    "@sinonjs/fake-timers": {
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-9.1.2.tgz",
+      "integrity": "sha512-BPS4ynJW/o92PUR4wgriz2Ud5gpST5vz6GQfMixEDK0Z8ZCUv2M7SkBLykH56T++Xs+8ln9zTGbOvNGIe02/jw==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.7.0"
+      }
+    },
+    "@sinonjs/samsam": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-6.1.1.tgz",
+      "integrity": "sha512-cZ7rKJTLiE7u7Wi/v9Hc2fs3Ucc3jrWeMgPHbbTCeVAB2S0wOBbYlkJVeNSL04i7fdhT8wIbDq1zhC/PXTD2SA==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.6.0",
+        "lodash.get": "^4.4.2",
+        "type-detect": "^4.0.8"
+      }
+    },
+    "@sinonjs/text-encoding": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.2.tgz",
+      "integrity": "sha512-sXXKG+uL9IrKqViTtao2Ws6dy0znu9sOaP1di/jKGW1M6VssO8vlpXCQcpZ+jisQ1tTFAC5Jo/EOzFbggBagFQ==",
+      "dev": true
+    },
     "@tsconfig/node10": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.9.tgz",
@@ -2986,6 +3149,21 @@
       "version": "18.6.2",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.6.2.tgz",
       "integrity": "sha512-KcfkBq9H4PI6Vpu5B/KoPeuVDAbmi+2mDBqGPGUgoL7yXQtcWGu2vJWmmRkneWK3Rh0nIAX192Aa87AqKHYChQ=="
+    },
+    "@types/sinon": {
+      "version": "10.0.13",
+      "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-10.0.13.tgz",
+      "integrity": "sha512-UVjDqJblVNQYvVNUsj0PuYYw0ELRmgt1Nt5Vk0pT5f16ROGfcKJY8o1HVuMOJOpD727RrGB9EGvoaTQE5tgxZQ==",
+      "dev": true,
+      "requires": {
+        "@types/sinonjs__fake-timers": "*"
+      }
+    },
+    "@types/sinonjs__fake-timers": {
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-8.1.2.tgz",
+      "integrity": "sha512-9GcLXF0/v3t80caGs5p2rRfkB+a8VBGLJZVih6CNFkx8IZ994wiKKLSRs9nuFwk1HevWs/1mnUmkApGrSGsShA==",
+      "dev": true
     },
     "@typescript-eslint/eslint-plugin": {
       "version": "5.35.1",
@@ -4219,6 +4397,12 @@
         "call-bind": "^1.0.2"
       }
     },
+    "isarray": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+      "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==",
+      "dev": true
+    },
     "isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -4255,6 +4439,12 @@
         "minimist": "^1.2.0"
       }
     },
+    "just-extend": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.2.1.tgz",
+      "integrity": "sha512-g3UB796vUFIY90VIv/WX3L2c8CS2MdWUww3CNrYmqza1Fg0DURc2K/O4YrnklBdQarSJ/y8JnJYDGc+1iumQjg==",
+      "dev": true
+    },
     "levn": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
@@ -4274,6 +4464,12 @@
         "p-locate": "^2.0.0",
         "path-exists": "^3.0.0"
       }
+    },
+    "lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==",
+      "dev": true
     },
     "lodash.merge": {
       "version": "4.6.2",
@@ -4337,6 +4533,19 @@
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true
+    },
+    "nise": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-5.1.1.tgz",
+      "integrity": "sha512-yr5kW2THW1AkxVmCnKEh4nbYkJdB3I7LUkiUgOvEkOp414mc2UMaHMA7pjq1nYowhdoJZGwEKGaQVbxfpWj10A==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.8.3",
+        "@sinonjs/fake-timers": ">=5",
+        "@sinonjs/text-encoding": "^0.7.1",
+        "just-extend": "^4.0.2",
+        "path-to-regexp": "^1.7.0"
+      }
     },
     "object-inspect": {
       "version": "1.12.2",
@@ -4452,6 +4661,15 @@
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true
+    },
+    "path-to-regexp": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
+      "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
+      "dev": true,
+      "requires": {
+        "isarray": "0.0.1"
+      }
     },
     "path-type": {
       "version": "4.0.0",
@@ -4574,6 +4792,28 @@
         "call-bind": "^1.0.0",
         "get-intrinsic": "^1.0.2",
         "object-inspect": "^1.9.0"
+      }
+    },
+    "sinon": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-14.0.0.tgz",
+      "integrity": "sha512-ugA6BFmE+WrJdh0owRZHToLd32Uw3Lxq6E6LtNRU+xTVBefx632h03Q7apXWRsRdZAJ41LB8aUfn2+O4jsDNMw==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.8.3",
+        "@sinonjs/fake-timers": "^9.1.2",
+        "@sinonjs/samsam": "^6.1.1",
+        "diff": "^5.0.0",
+        "nise": "^5.1.1",
+        "supports-color": "^7.2.0"
+      },
+      "dependencies": {
+        "diff": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-5.1.0.tgz",
+          "integrity": "sha512-D+mk+qE8VC/PAUrlAU34N+VfXev0ghe5ywmpqrawphmVZc1bEfn56uo9qpyGp1p4xpzOHkSW4ztBd6L7Xx4ACw==",
+          "dev": true
+        }
       }
     },
     "slash": {
@@ -4710,6 +4950,12 @@
       "requires": {
         "prelude-ls": "^1.2.1"
       }
+    },
+    "type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true
     },
     "type-fest": {
       "version": "0.20.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,10 +17,10 @@
       "devDependencies": {
         "@meyfa/eslint-config": "2.0.2",
         "@types/node": "18.6.2",
-        "@types/sinon": "^10.0.13",
+        "@types/sinon": "10.0.13",
         "eslint": "8.23.0",
         "rimraf": "3.0.2",
-        "sinon": "^14.0.0",
+        "sinon": "14.0.0",
         "typescript": "4.8.2"
       },
       "engines": {

--- a/package.json
+++ b/package.json
@@ -42,10 +42,10 @@
   "devDependencies": {
     "@meyfa/eslint-config": "2.0.2",
     "@types/node": "18.6.2",
-    "@types/sinon": "^10.0.13",
+    "@types/sinon": "10.0.13",
     "eslint": "8.23.0",
     "rimraf": "3.0.2",
-    "sinon": "^14.0.0",
+    "sinon": "14.0.0",
     "typescript": "4.8.2"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -42,8 +42,10 @@
   "devDependencies": {
     "@meyfa/eslint-config": "2.0.2",
     "@types/node": "18.6.2",
+    "@types/sinon": "^10.0.13",
     "eslint": "8.23.0",
     "rimraf": "3.0.2",
+    "sinon": "^14.0.0",
     "typescript": "4.8.2"
   },
   "dependencies": {

--- a/src/fs.ts
+++ b/src/fs.ts
@@ -1,0 +1,61 @@
+import { join } from 'path'
+import { readdir } from 'fs/promises'
+import { PathLike } from 'fs'
+
+
+/**
+ * Resolve a given set of (user-provided) input paths to explicit file names.
+ *
+ * Paths referring to singular files will be returned as-is, while paths referring to directories will be recursed into
+ * and the list of all deeply nested files will be returned.
+ *
+ * The resulting list will be filtered to only contain supported file extensions.
+ *
+ * @param paths The input paths.
+ * @param extensions The supported file extensions.
+ * @param readDirectory A function which can return the names of the files and folders in a directory (excluding '.' and '..')
+ * @returns An array containing all (matching and non-directory) file names explicitly.
+ */
+export async function resolveTestPaths(paths: string[], extensions: string[], readDirectory?: (path: PathLike) => Promise<string[]>): Promise<string[]> {
+    const resolvedPaths = []
+    for (const inputPath of paths) {
+        resolvedPaths.push(...await walkPath(
+            inputPath,
+            (fileName) => { return extensions.some((extension) => fileName.endsWith(extension)) },
+            readDirectory ?? readdir))
+    }
+    return resolvedPaths
+}
+
+export async function walkPath(path: string, predicate: (fileName: string) => boolean, readDirectory: (path: PathLike) => Promise<string[]>): Promise<string[]> {
+    const found = []
+    const stack = [path]
+
+    // Walk stack depth-first (in tree order)
+    while (stack.length > 0) {
+        const [item] = stack.splice(0, 1)
+        try {
+            // If item can be successfully read as a directory, we add its files to the top-of-stack.
+            const dirFileNames = await readDirectory(item)
+            stack.unshift(...dirFileNames.map((fileName) => join(item, fileName)))
+        } catch (err: unknown) {
+            if (isNodeError(err) && err.code === 'ENOTDIR') {
+                // item seems to refer to a file instead of a directory.
+                // We want to return it only if it was provided explicitly by the user, or it matches the predicate.
+                if (item === path || predicate(item)) {
+                    found.push(item)
+                }
+                continue
+            }
+            throw err
+        }
+    }
+
+    return found
+}
+
+
+// TS type guard
+function isNodeError(err: unknown): err is { code: unknown } {
+    return typeof err === 'object' && err != null && 'code' in err
+}

--- a/src/fs.ts
+++ b/src/fs.ts
@@ -2,7 +2,6 @@ import { join } from 'path'
 import { readdir } from 'fs/promises'
 import { PathLike } from 'fs'
 
-
 /**
  * Resolve a given set of (user-provided) input paths to explicit file names.
  *
@@ -16,46 +15,45 @@ import { PathLike } from 'fs'
  * @param readDirectory A function which can return the names of the files and folders in a directory (excluding '.' and '..')
  * @returns An array containing all (matching and non-directory) file names explicitly.
  */
-export async function resolveTestPaths(paths: string[], extensions: string[], readDirectory?: (path: PathLike) => Promise<string[]>): Promise<string[]> {
-    const resolvedPaths = []
-    for (const inputPath of paths) {
-        resolvedPaths.push(...await walkPath(
-            inputPath,
-            (fileName) => { return extensions.some((extension) => fileName.endsWith(extension)) },
-            readDirectory ?? readdir))
-    }
-    return resolvedPaths
+export async function resolveTestPaths (paths: string[], extensions: string[], readDirectory?: (path: PathLike) => Promise<string[]>): Promise<string[]> {
+  const resolvedPaths = []
+  for (const inputPath of paths) {
+    resolvedPaths.push(...await walkPath(
+      inputPath,
+      (fileName) => { return extensions.some((extension) => fileName.endsWith(extension)) },
+      readDirectory ?? readdir))
+  }
+  return resolvedPaths
 }
 
-export async function walkPath(path: string, predicate: (fileName: string) => boolean, readDirectory: (path: PathLike) => Promise<string[]>): Promise<string[]> {
-    const found = []
-    const stack = [path]
+export async function walkPath (path: string, predicate: (fileName: string) => boolean, readDirectory: (path: PathLike) => Promise<string[]>): Promise<string[]> {
+  const found = []
+  const stack = [path]
 
-    // Walk stack depth-first (in tree order)
-    while (stack.length > 0) {
-        const [item] = stack.splice(0, 1)
-        try {
-            // If item can be successfully read as a directory, we add its files to the top-of-stack.
-            const dirFileNames = await readDirectory(item)
-            stack.unshift(...dirFileNames.map((fileName) => join(item, fileName)))
-        } catch (err: unknown) {
-            if (isNodeError(err) && err.code === 'ENOTDIR') {
-                // item seems to refer to a file instead of a directory.
-                // We want to return it only if it was provided explicitly by the user, or it matches the predicate.
-                if (item === path || predicate(item)) {
-                    found.push(item)
-                }
-                continue
-            }
-            throw err
+  // Walk stack depth-first (in tree order)
+  while (stack.length > 0) {
+    const [item] = stack.splice(0, 1)
+    try {
+      // If item can be successfully read as a directory, we add its files to the top-of-stack.
+      const dirFileNames = await readDirectory(item)
+      stack.unshift(...dirFileNames.map((fileName) => join(item, fileName)))
+    } catch (err: unknown) {
+      if (isNodeError(err) && err.code === 'ENOTDIR') {
+        // item seems to refer to a file instead of a directory.
+        // We want to return it only if it was provided explicitly by the user, or it matches the predicate.
+        if (item === path || predicate(item)) {
+          found.push(item)
         }
+        continue
+      }
+      throw err
     }
+  }
 
-    return found
+  return found
 }
-
 
 // TS type guard
-function isNodeError(err: unknown): err is { code: unknown } {
-    return typeof err === 'object' && err != null && 'code' in err
+function isNodeError (err: unknown): err is { code: unknown } {
+  return typeof err === 'object' && err != null && 'code' in err
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,21 +1,21 @@
 import { spawn } from 'child_process'
 import { createRequire } from 'module'
 import { pathToFileURL } from 'url'
-import { resolveTestPaths } from './fs.js'
+import { resolveTestPaths } from './resolution.js'
 
-const DEFAULT_SUPPORTED_EXTENSIONS = ['.js', '.mjs', '.cjs', '.ts', '.mts', '.cts']
+const DEFAULT_TEST_EXTENSIONS = ['.js', '.mjs', '.cjs', '.ts', '.mts', '.cts']
 
-export function getSupportedExtensions (): string[] {
-  if (typeof process.env.SUPPORTED_EXTENSIONS !== 'undefined' && process.env.SUPPORTED_EXTENSIONS !== null) {
-    return process.env.SUPPORTED_EXTENSIONS.split(',').map(e => e.trim())
+export function getTestExtensions (): string[] {
+  if (typeof process.env.TEST_EXTENSIONS !== 'undefined' && process.env.TEST_EXTENSIONS !== null) {
+    return process.env.TEST_EXTENSIONS.split(',').map(e => e.trim())
   }
-  return DEFAULT_SUPPORTED_EXTENSIONS
+  return DEFAULT_TEST_EXTENSIONS
 }
 
 export async function main (): Promise<void> {
   const require = createRequire(import.meta.url)
   const esmLoader = pathToFileURL(require.resolve('ts-node/esm')).toString()
-  const extensions = getSupportedExtensions()
+  const extensions = getTestExtensions()
   const resolvedPaths = await resolveTestPaths(process.argv.slice(2), extensions)
   if (resolvedPaths.length === 0) {
     throw new Error('no test files found')

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,17 +3,16 @@ import { createRequire } from 'module'
 import { pathToFileURL } from 'url'
 import { resolveTestPaths } from './fs.js'
 
-
 const DEFAULT_SUPPORTED_EXTENSIONS = ['.js', '.mjs', '.cjs', '.ts', '.mts', '.cts']
 
-export function getSupportedExtensions() {
-  if(process.env.SUPPORTED_EXTENSIONS) {
+export function getSupportedExtensions (): string[] {
+  if (typeof process.env.SUPPORTED_EXTENSIONS !== 'undefined' && process.env.SUPPORTED_EXTENSIONS !== null) {
     return process.env.SUPPORTED_EXTENSIONS.split(',').map(e => e.trim())
   }
   return DEFAULT_SUPPORTED_EXTENSIONS
 }
 
-export async function main(): Promise<void> {
+export async function main (): Promise<void> {
   const require = createRequire(import.meta.url)
   const esmLoader = pathToFileURL(require.resolve('ts-node/esm')).toString()
   const extensions = getSupportedExtensions()
@@ -25,14 +24,13 @@ export async function main(): Promise<void> {
   spawnChild(esmLoader, resolvedPaths)
 }
 
-
 /**
  * Execute the Node.js test runner with the given loader and set of test file paths.
  *
  * @param loader The loader to use (fully resolved path to the loader script).
  * @param resolvedTestPaths The files under test.
  */
-function spawnChild(loader: string, resolvedTestPaths: string[]): void {
+function spawnChild (loader: string, resolvedTestPaths: string[]): void {
   const child = spawn(
     process.execPath,
     [
@@ -59,7 +57,7 @@ function spawnChild(loader: string, resolvedTestPaths: string[]): void {
   process.on('SIGINT', sendSignalToChild)
   process.on('SIGTERM', sendSignalToChild)
 
-  function sendSignalToChild(signal: string): void {
+  function sendSignalToChild (signal: string): void {
     if (child.pid != null) {
       process.kill(child.pid, signal)
     }

--- a/src/resolution.ts
+++ b/src/resolution.ts
@@ -20,7 +20,7 @@ export async function resolveTestPaths (paths: string[], extensions: string[], r
   for (const inputPath of paths) {
     resolvedPaths.push(...await walkPath(
       inputPath,
-      (fileName) => { return extensions.some((extension) => fileName.endsWith(extension)) },
+      (fileName) => extensions.some((extension) => fileName.endsWith(extension)),
       readDirectory ?? readdir))
   }
   return resolvedPaths

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,7 +1,5 @@
 import { describe, it } from 'node:test'
 import assert from 'node:assert/strict'
-import sinon from 'sinon'
-import * as fs from '../src/fs.js'
 import * as index from '../src/index.js'
 
 describe('index', () => {
@@ -10,7 +8,7 @@ describe('index', () => {
   })
 
   it('uses default extensions', () => {
-    const results = index.getSupportedExtensions()
+    const results = index.getTestExtensions()
     const expectedResults = ['.js', '.mjs', '.cjs', '.ts', '.mts', '.cts']
 
     for (let index = 0; index < results.length; index++) {
@@ -19,57 +17,10 @@ describe('index', () => {
   })
 
   it('gets supported extensions from environment variables', () => {
-    process.env.SUPPORTED_EXTENSIONS = '.foo,.bar,.baz'
+    process.env.TEST_EXTENSIONS = '.foo,.bar,.baz'
 
-    const results = index.getSupportedExtensions()
+    const results = index.getTestExtensions()
     const expectedResults = ['.foo', '.bar', '.baz']
-
-    for (let index = 0; index < results.length; index++) {
-      assert.equal(expectedResults[index], results[index])
-    }
-  })
-})
-
-describe('fs', () => {
-  it('walks directories', async () => {
-    const predicate = sinon.stub()
-    predicate.withArgs('some-project/file.ts').returns(true)
-    predicate.withArgs('some-project/subdir1/subfile.ts').returns(true)
-    predicate.returns(false)
-
-    const dirReader = sinon.stub()
-    dirReader.withArgs('some-project').returns(Promise.resolve(['subdir1', 'subdir2', 'file.ts']))
-    dirReader.withArgs('some-project/subdir1').returns(Promise.resolve(['subfile.ts']))
-    dirReader.withArgs('some-project/subdir2').returns(Promise.resolve([]))
-    // eslint-disable-next-line prefer-promise-reject-errors
-    dirReader.withArgs('some-project/file.ts').returns(Promise.reject({ code: 'ENOTDIR' }))
-    // eslint-disable-next-line prefer-promise-reject-errors
-    dirReader.withArgs('some-project/subdir1/subfile.ts').returns(Promise.reject({ code: 'ENOTDIR' }))
-
-    const results = (await fs.walkPath('some-project', predicate, dirReader)).sort()
-    const expectedResults = ['some-project/file.ts', 'some-project/subdir1/subfile.ts'].sort()
-
-    assert.equal(1, predicate.withArgs('some-project/file.ts').callCount)
-    assert.equal(1, predicate.withArgs('some-project/subdir1/subfile.ts').callCount)
-
-    for (let index = 0; index < results.length; index++) {
-      assert.equal(expectedResults[index], results[index])
-    }
-  })
-
-  it('resolves test paths', async () => {
-    const files = ['a.ts', 'a.test.ts', 'b.ts', 'b.test.ts']
-    const extensions = ['.test.ts']
-
-    const dirReader = sinon.stub()
-    dirReader.withArgs('project').returns(Promise.resolve(files))
-    for (const file of files) {
-      // eslint-disable-next-line prefer-promise-reject-errors
-      dirReader.withArgs(`project/${file}`).returns(Promise.reject({ code: 'ENOTDIR' }))
-    }
-
-    const results = (await fs.resolveTestPaths(['project'], extensions, dirReader)).sort()
-    const expectedResults = ['project/a.test.ts', 'project/b.test.ts'].sort()
 
     for (let index = 0; index < results.length; index++) {
       assert.equal(expectedResults[index], results[index])

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -4,39 +4,33 @@ import sinon from 'sinon'
 import * as fs from '../src/fs.js'
 import * as index from '../src/index.js'
 
-
 describe('index', () => {
-
   it('exports main()', () => {
     assert.equal(typeof index.main, 'function')
   })
 
   it('uses default extensions', () => {
-
     const results = index.getSupportedExtensions()
     const expectedResults = ['.js', '.mjs', '.cjs', '.ts', '.mts', '.cts']
-    
-    for(let index in results) {
+
+    for (let index = 0; index < results.length; index++) {
       assert.equal(expectedResults[index], results[index])
     }
-
   })
 
   it('gets supported extensions from environment variables', () => {
     process.env.SUPPORTED_EXTENSIONS = '.foo,.bar,.baz'
-    
+
     const results = index.getSupportedExtensions()
     const expectedResults = ['.foo', '.bar', '.baz']
-    
-    for(let index in results) {
+
+    for (let index = 0; index < results.length; index++) {
       assert.equal(expectedResults[index], results[index])
     }
   })
-
 })
 
 describe('fs', () => {
-
   it('walks directories', async () => {
     const predicate = sinon.stub()
     predicate.withArgs('some-project/file.ts').returns(true)
@@ -47,38 +41,38 @@ describe('fs', () => {
     dirReader.withArgs('some-project').returns(Promise.resolve(['subdir1', 'subdir2', 'file.ts']))
     dirReader.withArgs('some-project/subdir1').returns(Promise.resolve(['subfile.ts']))
     dirReader.withArgs('some-project/subdir2').returns(Promise.resolve([]))
-    dirReader.withArgs('some-project/file.ts').returns(Promise.reject({code: 'ENOTDIR'}))
-    dirReader.withArgs('some-project/subdir1/subfile.ts').returns(Promise.reject({code: 'ENOTDIR'}))
-    
-    const results = (await fs.walkPath('some-project', predicate, dirReader)).sort();
-    const expectedResults = ['some-project/file.ts', 'some-project/subdir1/subfile.ts'].sort();
+    // eslint-disable-next-line prefer-promise-reject-errors
+    dirReader.withArgs('some-project/file.ts').returns(Promise.reject({ code: 'ENOTDIR' }))
+    // eslint-disable-next-line prefer-promise-reject-errors
+    dirReader.withArgs('some-project/subdir1/subfile.ts').returns(Promise.reject({ code: 'ENOTDIR' }))
+
+    const results = (await fs.walkPath('some-project', predicate, dirReader)).sort()
+    const expectedResults = ['some-project/file.ts', 'some-project/subdir1/subfile.ts'].sort()
 
     assert.equal(1, predicate.withArgs('some-project/file.ts').callCount)
     assert.equal(1, predicate.withArgs('some-project/subdir1/subfile.ts').callCount)
 
-    for(let index in results) {
+    for (let index = 0; index < results.length; index++) {
       assert.equal(expectedResults[index], results[index])
     }
   })
 
   it('resolves test paths', async () => {
-
     const files = ['a.ts', 'a.test.ts', 'b.ts', 'b.test.ts']
     const extensions = ['.test.ts']
 
     const dirReader = sinon.stub()
     dirReader.withArgs('project').returns(Promise.resolve(files))
-    for(let file of files) {
-      dirReader.withArgs(`project/${file}`).returns(Promise.reject({code: 'ENOTDIR'}))
+    for (const file of files) {
+      // eslint-disable-next-line prefer-promise-reject-errors
+      dirReader.withArgs(`project/${file}`).returns(Promise.reject({ code: 'ENOTDIR' }))
     }
 
     const results = (await fs.resolveTestPaths(['project'], extensions, dirReader)).sort()
-    const expectedResults = ['project/a.test.ts', 'project/b.test.ts'].sort();
+    const expectedResults = ['project/a.test.ts', 'project/b.test.ts'].sort()
 
-    for(let index in results) {
+    for (let index = 0; index < results.length; index++) {
       assert.equal(expectedResults[index], results[index])
     }
-
   })
-
 })

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,11 +1,84 @@
 import { describe, it } from 'node:test'
-import assert from 'assert/strict'
+import assert from 'node:assert/strict'
+import sinon from 'sinon'
+import * as fs from '../src/fs.js'
 import * as index from '../src/index.js'
 
-// These are dummy tests for now.
 
 describe('index', () => {
+
   it('exports main()', () => {
     assert.equal(typeof index.main, 'function')
   })
+
+  it('uses default extensions', () => {
+
+    const results = index.getSupportedExtensions()
+    const expectedResults = ['.js', '.mjs', '.cjs', '.ts', '.mts', '.cts']
+    
+    for(let index in results) {
+      assert.equal(expectedResults[index], results[index])
+    }
+
+  })
+
+  it('gets supported extensions from environment variables', () => {
+    process.env.SUPPORTED_EXTENSIONS = '.foo,.bar,.baz'
+    
+    const results = index.getSupportedExtensions()
+    const expectedResults = ['.foo', '.bar', '.baz']
+    
+    for(let index in results) {
+      assert.equal(expectedResults[index], results[index])
+    }
+  })
+
+})
+
+describe('fs', () => {
+
+  it('walks directories', async () => {
+    const predicate = sinon.stub()
+    predicate.withArgs('some-project/file.ts').returns(true)
+    predicate.withArgs('some-project/subdir1/subfile.ts').returns(true)
+    predicate.returns(false)
+
+    const dirReader = sinon.stub()
+    dirReader.withArgs('some-project').returns(Promise.resolve(['subdir1', 'subdir2', 'file.ts']))
+    dirReader.withArgs('some-project/subdir1').returns(Promise.resolve(['subfile.ts']))
+    dirReader.withArgs('some-project/subdir2').returns(Promise.resolve([]))
+    dirReader.withArgs('some-project/file.ts').returns(Promise.reject({code: 'ENOTDIR'}))
+    dirReader.withArgs('some-project/subdir1/subfile.ts').returns(Promise.reject({code: 'ENOTDIR'}))
+    
+    const results = (await fs.walkPath('some-project', predicate, dirReader)).sort();
+    const expectedResults = ['some-project/file.ts', 'some-project/subdir1/subfile.ts'].sort();
+
+    assert.equal(1, predicate.withArgs('some-project/file.ts').callCount)
+    assert.equal(1, predicate.withArgs('some-project/subdir1/subfile.ts').callCount)
+
+    for(let index in results) {
+      assert.equal(expectedResults[index], results[index])
+    }
+  })
+
+  it('resolves test paths', async () => {
+
+    const files = ['a.ts', 'a.test.ts', 'b.ts', 'b.test.ts']
+    const extensions = ['.test.ts']
+
+    const dirReader = sinon.stub()
+    dirReader.withArgs('project').returns(Promise.resolve(files))
+    for(let file of files) {
+      dirReader.withArgs(`project/${file}`).returns(Promise.reject({code: 'ENOTDIR'}))
+    }
+
+    const results = (await fs.resolveTestPaths(['project'], extensions, dirReader)).sort()
+    const expectedResults = ['project/a.test.ts', 'project/b.test.ts'].sort();
+
+    for(let index in results) {
+      assert.equal(expectedResults[index], results[index])
+    }
+
+  })
+
 })

--- a/test/resolution.test.ts
+++ b/test/resolution.test.ts
@@ -1,0 +1,51 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import sinon from 'sinon'
+import * as resolution from '../src/resolution.js'
+
+describe('resolution', () => {
+  it('walks directories', async () => {
+    const predicate = sinon.stub()
+    predicate.withArgs('some-project/file.ts').returns(true)
+    predicate.withArgs('some-project/subdir1/subfile.ts').returns(true)
+    predicate.returns(false)
+
+    const dirReader = sinon.stub()
+    dirReader.withArgs('some-project').returns(Promise.resolve(['subdir1', 'subdir2', 'file.ts']))
+    dirReader.withArgs('some-project/subdir1').returns(Promise.resolve(['subfile.ts']))
+    dirReader.withArgs('some-project/subdir2').returns(Promise.resolve([]))
+    // eslint-disable-next-line prefer-promise-reject-errors
+    dirReader.withArgs('some-project/file.ts').returns(Promise.reject({ code: 'ENOTDIR' }))
+    // eslint-disable-next-line prefer-promise-reject-errors
+    dirReader.withArgs('some-project/subdir1/subfile.ts').returns(Promise.reject({ code: 'ENOTDIR' }))
+
+    const results = (await resolution.walkPath('some-project', predicate, dirReader)).sort()
+    const expectedResults = ['some-project/file.ts', 'some-project/subdir1/subfile.ts'].sort()
+
+    assert.equal(1, predicate.withArgs('some-project/file.ts').callCount)
+    assert.equal(1, predicate.withArgs('some-project/subdir1/subfile.ts').callCount)
+
+    for (let index = 0; index < results.length; index++) {
+      assert.equal(expectedResults[index], results[index])
+    }
+  })
+
+  it('resolves test paths', async () => {
+    const files = ['a.ts', 'a.test.ts', 'b.ts', 'b.test.ts']
+    const extensions = ['.test.ts']
+
+    const dirReader = sinon.stub()
+    dirReader.withArgs('project').returns(Promise.resolve(files))
+    for (const file of files) {
+      // eslint-disable-next-line prefer-promise-reject-errors
+      dirReader.withArgs(`project/${file}`).returns(Promise.reject({ code: 'ENOTDIR' }))
+    }
+
+    const results = (await resolution.resolveTestPaths(['project'], extensions, dirReader)).sort()
+    const expectedResults = ['project/a.test.ts', 'project/b.test.ts'].sort()
+
+    for (let index = 0; index < results.length; index++) {
+      assert.equal(expectedResults[index], results[index])
+    }
+  })
+})

--- a/test/resolution.test.ts
+++ b/test/resolution.test.ts
@@ -1,29 +1,30 @@
 import { describe, it } from 'node:test'
 import assert from 'node:assert/strict'
 import sinon from 'sinon'
+import path from 'node:path'
 import * as resolution from '../src/resolution.js'
 
 describe('resolution', () => {
   it('walks directories', async () => {
     const predicate = sinon.stub()
-    predicate.withArgs('some-project/file.ts').returns(true)
-    predicate.withArgs('some-project/subdir1/subfile.ts').returns(true)
+    predicate.withArgs(path.join('some-project', 'file.ts')).returns(true)
+    predicate.withArgs(path.join('some-project', 'subdir1', 'subfile.ts')).returns(true)
     predicate.returns(false)
 
     const dirReader = sinon.stub()
     dirReader.withArgs('some-project').returns(Promise.resolve(['subdir1', 'subdir2', 'file.ts']))
-    dirReader.withArgs('some-project/subdir1').returns(Promise.resolve(['subfile.ts']))
-    dirReader.withArgs('some-project/subdir2').returns(Promise.resolve([]))
+    dirReader.withArgs(path.join('some-project', 'subdir1')).returns(Promise.resolve(['subfile.ts']))
+    dirReader.withArgs(path.join('some-project', 'subdir2')).returns(Promise.resolve([]))
     // eslint-disable-next-line prefer-promise-reject-errors
-    dirReader.withArgs('some-project/file.ts').returns(Promise.reject({ code: 'ENOTDIR' }))
+    dirReader.withArgs(path.join('some-project', 'file.ts')).returns(Promise.reject({ code: 'ENOTDIR' }))
     // eslint-disable-next-line prefer-promise-reject-errors
-    dirReader.withArgs('some-project/subdir1/subfile.ts').returns(Promise.reject({ code: 'ENOTDIR' }))
+    dirReader.withArgs(path.join('some-project', 'subdir1', 'subfile.ts')).returns(Promise.reject({ code: 'ENOTDIR' }))
 
     const results = (await resolution.walkPath('some-project', predicate, dirReader)).sort()
-    const expectedResults = ['some-project/file.ts', 'some-project/subdir1/subfile.ts'].sort()
+    const expectedResults = [path.join('some-project', 'file.ts'), path.join('some-project', 'subdir1', 'subfile.ts')].sort()
 
-    assert.equal(1, predicate.withArgs('some-project/file.ts').callCount)
-    assert.equal(1, predicate.withArgs('some-project/subdir1/subfile.ts').callCount)
+    assert.equal(1, predicate.withArgs(path.join('some-project', 'file.ts')).callCount)
+    assert.equal(1, predicate.withArgs(path.join('some-project', 'subdir1', 'subfile.ts')).callCount)
 
     for (let index = 0; index < results.length; index++) {
       assert.equal(expectedResults[index], results[index])
@@ -38,11 +39,11 @@ describe('resolution', () => {
     dirReader.withArgs('project').returns(Promise.resolve(files))
     for (const file of files) {
       // eslint-disable-next-line prefer-promise-reject-errors
-      dirReader.withArgs(`project/${file}`).returns(Promise.reject({ code: 'ENOTDIR' }))
+      dirReader.withArgs(path.join('project', file)).returns(Promise.reject({ code: 'ENOTDIR' }))
     }
 
     const results = (await resolution.resolveTestPaths(['project'], extensions, dirReader)).sort()
-    const expectedResults = ['project/a.test.ts', 'project/b.test.ts'].sort()
+    const expectedResults = [path.join('project', 'a.test.ts'), path.join('project', 'b.test.ts')].sort()
 
     for (let index = 0; index < results.length; index++) {
       assert.equal(expectedResults[index], results[index])

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "lib": ["ES2022"],
     "target": "ES2022",
     "module": "ES2022",
     "moduleResolution": "Node",


### PR DESCRIPTION
# Summary

* Add SUPPORTED_EXTENSIONS environment variable
* Split FS operations out into their own module
* Add tests


# Custom Extensions

Adding the ability to supply a custom `SUPPORTED_EXTENSIONS` environment variable gives the user more power when setting up their test runner. For example, a user may choose to write their test files adjacent to their source files and give it the suffix `.test.ts`. This change will allow a user to supply `SUPPORTED_EXTENSIONS=.test.ts` to selectively run TypeScript files within their source directory, rather than maintaining a separate test directory structure.

This is implemented within the `getSupportedExtensions` function in the `index.ts` file.


# FS Module

Filesystem operations have been shifted out of `index.ts` and into `fs.ts`.
The `resolveTestPaths` function has been updated to allow the supply of an array of allowed extensions through a new `extensions` parameter, rather than directly accessing the hard-coded array of allowed extensions. This also makes the function more testable.

The `resolveTestPaths` and `walkPath` functions have been updated to include a `readDirectory` function. In regular use, this defaults to the already used `readdir` function, however by including this parameter, it allows for other functions or mechanisms to be used to read a directory. This is primarily done to make the code more testable, but could also be used in the future to perform further pruning of the directory structure in advance to remove or reduce wasted `readDirectory` calls on files or paths that will never be of interest.


# Tests

* Ensure that the `getSupportedExtensions` function returns the expected built-in supported extensions
* Ensure that the `getSupportedExtensions` function returns the list of extensions supplied by the `SUPPORTED_EXTENSIONS` environment variable if it is present
* Ensure that the `walkPath` function successfully walks a basic directory structure with files and folders
* Ensure that the `resolveTestPaths` function successfully walks a basic directory structure and retrieves only the files of interest
* 