### PR TITLE
chore(tsconfig): Set "lib" explicitly to avoid DOM types in global

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "lib": ["ES2022"],
     "target": "ES2022",
     "module": "ES2022",
     "moduleResolution": "Node",


### PR DESCRIPTION
TSConfig "lib" by default includes DOM types which pollute the global namespace. This patch sets "lib" explicitly to avoid this behavior, which could lead to accidental bugs.