### PR TITLE
chore(ci): Test on Windows in addition to Linux

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,12 +20,15 @@ jobs:
       - run: npm run lint
 
   test:
-    name: test - Node.js ${{ matrix.node-version }}
-    runs-on: ubuntu-latest
     strategy:
       matrix:
+        os:
+          - ubuntu-latest
+          - windows-latest
         node-version:
           - 18
+    name: test (${{ matrix.os }}) - Node.js ${{ matrix.node-version }}
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3


### PR DESCRIPTION
Windows uses a different path separator than Linux. We ran into a problem with failing tests on Windows in #10, though they succeeded on Linux. Having CI for Windows should help us notice such problems in the future.