### PR TITLE
chore: Remove rimraf dev dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,6 @@
         "@types/sinon": "10.0.13",
         "@types/yargs": "17.0.17",
         "eslint": "8.35.0",
-        "rimraf": "4.1.1",
         "sinon": "15.0.1",
         "typescript": "4.9.5"
       },
@@ -2630,21 +2629,6 @@
       "engines": {
         "iojs": ">=1.0.0",
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/rimraf": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-4.1.1.tgz",
-      "integrity": "sha512-Z4Y81w8atcvaJuJuBB88VpADRH66okZAuEm+Jtaufa+s7rZmIz+Hik2G53kGaNytE7lsfXyWktTmfVz0H9xuDg==",
-      "dev": true,
-      "bin": {
-        "rimraf": "dist/cjs/src/bin.js"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/run-parallel": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "ts-node-test": "dist/bin.js"
   },
   "scripts": {
-    "build": "rimraf dist && tsc",
+    "build": "node -e \"fs.rmSync('./dist',{force:true,recursive:true})\" && tsc",
     "lint": "tsc --noEmit -p tsconfig.lint.json && eslint --ignore-path .gitignore .",
     "lint-fix": "tsc --noEmit -p tsconfig.lint.json && eslint --fix --ignore-path .gitignore .",
     "test": "npm run build && node dist/bin.js test/",
@@ -45,7 +45,6 @@
     "@types/sinon": "10.0.13",
     "@types/yargs": "17.0.17",
     "eslint": "8.35.0",
-    "rimraf": "4.1.1",
     "sinon": "15.0.1",
     "typescript": "4.9.5"
   },


### PR DESCRIPTION
Since we depend on Node.js anyway, we can use its CLI to remove the dist directory, without having to depend on a 3rd-party package.