### PR TITLE
fix: Update 'yargs' and provide command handler

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,11 +6,11 @@
   "packages": {
     "": {
       "name": "ts-node-test",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "license": "MIT",
       "dependencies": {
         "ts-node": "10.9.1",
-        "yargs": "17.6.2"
+        "yargs": "17.7.1"
       },
       "bin": {
         "ts-node-test": "dist/bin.js"
@@ -19,7 +19,7 @@
         "@meyfa/eslint-config": "3.0.0",
         "@types/node": "18.15.3",
         "@types/sinon": "10.0.13",
-        "@types/yargs": "17.0.17",
+        "@types/yargs": "17.0.22",
         "eslint": "8.35.0",
         "sinon": "15.0.1",
         "typescript": "5.0.2"
@@ -284,9 +284,9 @@
       "dev": true
     },
     "node_modules/@types/yargs": {
-      "version": "17.0.17",
-      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.17.tgz",
-      "integrity": "sha512-72bWxFKTK6uwWJAVT+3rF6Jo6RTojiJ27FQo8Rf60AL+VZbzoVPnMFhKsUnbjR8A3BTCYQ7Mv3hnl8T0A+CX9g==",
+      "version": "17.0.22",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.22.tgz",
+      "integrity": "sha512-pet5WJ9U8yPVRhkwuEIp5ktAeAqRZOq4UdAyWLWzxbtpyXnzbtLdKiXAjJzi/KLmPGS9wk86lUFWZFN6sISo4g==",
       "dev": true,
       "dependencies": {
         "@types/yargs-parser": "*"
@@ -3076,9 +3076,9 @@
       "dev": true
     },
     "node_modules/yargs": {
-      "version": "17.6.2",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.6.2.tgz",
-      "integrity": "sha512-1/9UrdHjDZc0eOU0HxOHoS78C69UD3JRMvzlJ7S79S2nTaWRA/whGCTV8o9e/N/1Va9YIV7Q4sOxD8VV4pCWOw==",
+      "version": "17.7.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.1.tgz",
+      "integrity": "sha512-cwiTb08Xuv5fqF4AovYacTFNxk62th7LKJ6BL9IGUpTJrWoU7/7WdQGTP2SjKf1dUNBGzDd28p/Yfs/GI6JrLw==",
       "dependencies": {
         "cliui": "^8.0.1",
         "escalade": "^3.1.1",

--- a/package.json
+++ b/package.json
@@ -43,14 +43,14 @@
     "@meyfa/eslint-config": "3.0.0",
     "@types/node": "18.15.3",
     "@types/sinon": "10.0.13",
-    "@types/yargs": "17.0.17",
+    "@types/yargs": "17.0.22",
     "eslint": "8.35.0",
     "sinon": "15.0.1",
     "typescript": "5.0.2"
   },
   "dependencies": {
     "ts-node": "10.9.1",
-    "yargs": "17.6.2"
+    "yargs": "17.7.1"
   },
   "peerDependencies": {
     "typescript": "^4.0.0 || ^5.0.0"

--- a/src/bin.ts
+++ b/src/bin.ts
@@ -3,7 +3,7 @@
 import { main } from './index.js'
 import yargs from 'yargs'
 
-const parsedArgs = yargs(process.argv.slice(2)).command('* <paths...>', 'Run tests', (yargs) => {
+await yargs(process.argv.slice(2)).command('* <paths...>', 'Run tests', (yargs) => {
   return yargs.options({
     'test-name-pattern': {
       type: 'string',
@@ -49,6 +49,6 @@ const parsedArgs = yargs(process.argv.slice(2)).command('* <paths...>', 'Run tes
     demandOption: true,
     description: 'Paths to test files'
   })
-}).parseSync()
-
-await main(parsedArgs.paths, parsedArgs)
+}, async (parsedArgs) => {
+  await main(parsedArgs.paths, parsedArgs)
+}).parse()


### PR DESCRIPTION
The recent update to yargs types broke command inference (see PR #35). This can be solved by providing a handler to the command directly.