### PR TITLE
test: Improve assertions

### DIFF
--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,5 +1,5 @@
 import { describe, it } from 'node:test'
-import assert from 'node:assert/strict'
+import assert from 'node:assert'
 import * as index from '../src/index.js'
 
 describe('index', () => {
@@ -11,9 +11,7 @@ describe('index', () => {
     const results = index.getTestExtensions()
     const expectedResults = ['.js', '.mjs', '.cjs', '.ts', '.mts', '.cts']
 
-    for (let index = 0; index < results.length; index++) {
-      assert.equal(expectedResults[index], results[index])
-    }
+    assert.deepStrictEqual(results, expectedResults)
   })
 
   it('gets supported extensions from environment variables', () => {
@@ -22,8 +20,6 @@ describe('index', () => {
     const results = index.getTestExtensions()
     const expectedResults = ['.foo', '.bar', '.baz']
 
-    for (let index = 0; index < results.length; index++) {
-      assert.equal(expectedResults[index], results[index])
-    }
+    assert.deepStrictEqual(results, expectedResults)
   })
 })


### PR DESCRIPTION
This patch improves the assertions in the following ways:

* usage of `node:assert` import, since it works better with TypeScript
* `deepStrictEqual()` instead of a for-loop, which could fail when lengths were mismatched
* sinon's `.resolves()` and `.rejects()` utility functions to clean up the Promise-based stubs
* fixed order of actual/expected in asserts
* added an `ENOTDIR()` helper to construct a proper `Error`