### PR TITLE
fix: Don't recurse into node_modules unless explicitly requested

### DIFF
--- a/src/resolution.ts
+++ b/src/resolution.ts
@@ -36,7 +36,7 @@ export async function walkPath (path: string, predicate: (fileName: string) => b
     try {
       // If item can be successfully read as a directory, we add its files to the top-of-stack.
       const dirFileNames = await readDirectory(item)
-      stack.unshift(...dirFileNames.map((fileName) => join(item, fileName)))
+      stack.unshift(...dirFileNames.filter((fileName) => fileName !== 'node_modules').map((fileName) => join(item, fileName)))
     } catch (err: unknown) {
       if (isNodeError(err) && err.code === 'ENOTDIR') {
         // item seems to refer to a file instead of a directory.

--- a/test/resolution.test.ts
+++ b/test/resolution.test.ts
@@ -17,7 +17,6 @@ describe('resolution', () => {
     dirReader.withArgs('some-project').resolves(['subdir1', 'subdir2', 'file.ts'])
     dirReader.withArgs(path.join('some-project', 'subdir1')).resolves(['subfile.ts'])
     dirReader.withArgs(path.join('some-project', 'subdir2')).resolves([])
-    // eslint-disable-next-line prefer-promise-reject-errors
     dirReader.withArgs(path.join('some-project', 'file.ts')).rejects(ENOTDIR())
     dirReader.withArgs(path.join('some-project', 'subdir1', 'subfile.ts')).rejects(ENOTDIR())
 
@@ -37,12 +36,50 @@ describe('resolution', () => {
     const dirReader = sinon.stub()
     dirReader.withArgs('project').resolves(files)
     for (const file of files) {
-      // eslint-disable-next-line prefer-promise-reject-errors
       dirReader.withArgs(path.join('project', file)).rejects(ENOTDIR())
     }
 
     const results = await resolution.resolveTestPaths(['project'], extensions, dirReader)
     const expectedResults = [path.join('project', 'a.test.ts'), path.join('project', 'b.test.ts')]
     assert.deepStrictEqual(results.sort(), expectedResults.sort())
+  })
+
+  it('does not descend into node_modules unless explicitly provided', async () => {
+    const predicate = sinon.stub()
+    predicate.withArgs(path.join('foo', 'node_modules', 'file1.ts')).returns(true)
+    predicate.withArgs(path.join('foo', 'bar', 'file2.ts')).returns(true)
+    predicate.withArgs(path.join('foo', 'bar', 'node_modules', 'file3.ts')).returns(true)
+    predicate.returns(false)
+
+    const dirReader = sinon.stub()
+
+    // foo, foo/node_modules, foo/node_modules/file1.ts
+    dirReader.withArgs('foo').resolves(['node_modules', 'bar'])
+    dirReader.withArgs(path.join('foo', 'node_modules')).resolves(['file1.ts'])
+    dirReader.withArgs(path.join('foo', 'node_modules', 'file1.ts')).rejects(ENOTDIR())
+
+    // foo/bar, foo/bar/file2.ts
+    dirReader.withArgs(path.join('foo', 'bar')).resolves(['file2.ts', 'node_modules'])
+    dirReader.withArgs(path.join('foo', 'bar', 'file2.ts')).rejects(ENOTDIR())
+
+    // foo/bar/node_modules, foo/bar/node_modules/file3.ts
+    dirReader.withArgs(path.join('foo', 'bar', 'node_modules')).resolves(['file3.ts'])
+    dirReader.withArgs(path.join('foo', 'bar', 'node_modules', 'file3.ts')).rejects(ENOTDIR())
+
+    const results = await resolution.walkPath('foo', predicate, dirReader)
+    assert.deepStrictEqual(results, [path.join('foo', 'bar', 'file2.ts')])
+    assert.equal(predicate.callCount, 1)
+    assert.equal(predicate.withArgs(path.join('foo', 'node_modules', 'file1.ts')).callCount, 0)
+    assert.equal(predicate.withArgs(path.join('foo', 'bar', 'file2.ts')).callCount, 1)
+    assert.equal(predicate.withArgs(path.join('foo', 'bar', 'node_modules', 'file3.ts')).callCount, 0)
+
+    predicate.resetHistory()
+
+    const results2 = await resolution.walkPath(path.join('foo', 'node_modules'), predicate, dirReader)
+    assert.deepStrictEqual(results2, [path.join('foo', 'node_modules', 'file1.ts')])
+    assert.equal(predicate.callCount, 1)
+    assert.equal(predicate.withArgs(path.join('foo', 'node_modules', 'file1.ts')).callCount, 1)
+    assert.equal(predicate.withArgs(path.join('foo', 'bar', 'file2.ts')).callCount, 0)
+    assert.equal(predicate.withArgs(path.join('foo', 'bar', 'node_modules', 'file3.ts')).callCount, 0)
   })
 })


### PR DESCRIPTION
Node's test runner skips `node_modules` directories by default, unless one is explicitly provided as an input path. This patch adds a filtering step to `walkPath()`, so that ts-node-test behaves the same.